### PR TITLE
Feature/separate players

### DIFF
--- a/tafl/lib/impl/captures.ex
+++ b/tafl/lib/impl/captures.ex
@@ -7,7 +7,7 @@ defmodule Tafl.Impl.Captures do
     [{r, c - 1}, {r, c + 1}, {r - 1, c}, {r + 1, c}]
   end
 
-  @spec perform_captures(Board.t(), Type.player(), Type.rc_loc()) :: Board.t()
+  @spec perform_captures(Board.t(), Type.player_indicator(), Type.rc_loc()) :: Board.t()
   def perform_captures(board, player, new_location) do
     directions(new_location)
     |> Enum.map(&check_if_captured(&1, player, board))
@@ -15,7 +15,8 @@ defmodule Tafl.Impl.Captures do
     |> Enum.reduce(board, &capture(&1, &2))
   end
 
-  @spec check_if_captured(Type.rc_loc(), Type.player(), Board.t()) :: {Type.rc_loc(), boolean()}
+  @spec check_if_captured(Type.rc_loc(), Type.player_indicator(), Board.t()) ::
+          {Type.rc_loc(), boolean()}
   defp check_if_captured(check_location, attacker, board) do
     IO.puts("****************")
     IO.puts("checking if captured")
@@ -57,7 +58,7 @@ defmodule Tafl.Impl.Captures do
     Map.get(coord_map, location, %Space{})
   end
 
-  @spec captured?(Piece.t(), Type.player(), list(Space.t())) :: boolean()
+  @spec captured?(Piece.t(), Type.player_indicator(), list(Space.t())) :: boolean()
   defp captured?(piece, defender, surrounding_spaces)
        when piece.kind == :king and piece.owner == defender do
     attacker = Utils.other_player(defender)
@@ -86,7 +87,7 @@ defmodule Tafl.Impl.Captures do
 
   defp captured?(_piece, _defender, _surrounding_spaces), do: false
 
-  @spec space_can_capture?(Space.t(), Type.player()) :: boolean()
+  @spec space_can_capture?(Space.t(), Type.player_indicator()) :: boolean()
   defp space_can_capture?(space, attacker)
        when space.piece.owner == attacker or space.kind == :corner or space.kind == :center do
     IO.puts("checking if space can capture because attacker present")

--- a/tafl/lib/impl/game.ex
+++ b/tafl/lib/impl/game.ex
@@ -1,5 +1,5 @@
 defmodule Tafl.Impl.Game do
-  alias Tafl.Impl.{Board, Captures, Rules, Utils, WinConditions}
+  alias Tafl.Impl.{Board, Captures, Player, Rules, Utils, WinConditions}
   alias Tafl.Type
 
   @type t :: %__MODULE__{
@@ -7,7 +7,8 @@ defmodule Tafl.Impl.Game do
           turn: Type.player_indicator(),
           state: Type.state(),
           message: String.t(),
-          winner: Type.player_indicator() | nil
+          winner: Type.player_indicator() | nil,
+          players: %{Type.player_indicator() => Player.t()}
         }
 
   defstruct(
@@ -15,7 +16,8 @@ defmodule Tafl.Impl.Game do
     turn: nil,
     state: :initializing,
     message: "",
-    winner: nil
+    winner: nil,
+    players: %{}
   )
 
   @spec new() :: t()

--- a/tafl/lib/impl/game.ex
+++ b/tafl/lib/impl/game.ex
@@ -4,10 +4,10 @@ defmodule Tafl.Impl.Game do
 
   @type t :: %__MODULE__{
           board: Board.t(),
-          turn: Type.player(),
+          turn: Type.player_indicator(),
           state: Type.state(),
           message: String.t(),
-          winner: Type.player() | nil
+          winner: Type.player_indicator() | nil
         }
 
   defstruct(
@@ -76,7 +76,7 @@ defmodule Tafl.Impl.Game do
     do_evaluate_win(game, winner?(game))
   end
 
-  @spec do_evaluate_win(t(), {boolean(), Type.player()}) :: t()
+  @spec do_evaluate_win(t(), {boolean(), Type.player_indicator()}) :: t()
   defp do_evaluate_win(game, {winner, player}) when winner == true do
     %__MODULE__{
       game
@@ -88,7 +88,7 @@ defmodule Tafl.Impl.Game do
 
   defp do_evaluate_win(game, _no_winner), do: game
 
-  @spec winner?(t()) :: {boolean(), Type.player()}
+  @spec winner?(t()) :: {boolean(), Type.player_indicator()}
   defp winner?(game) do
     WinConditions.check(game)
   end

--- a/tafl/lib/impl/piece.ex
+++ b/tafl/lib/impl/piece.ex
@@ -4,12 +4,12 @@ defmodule Tafl.Impl.Piece do
 
   @type t :: %__MODULE__{
           kind: piece_kind() | nil,
-          owner: Type.player() | nil
+          owner: Type.player_indicator() | nil
         }
 
   defstruct [:kind, :owner]
 
-  @spec make_piece(Type.player(), piece_kind()) :: t()
+  @spec make_piece(Type.player_indicator(), piece_kind()) :: t()
   def make_piece(owner, kind) do
     %__MODULE__{owner: owner, kind: kind}
   end

--- a/tafl/lib/impl/player.ex
+++ b/tafl/lib/impl/player.ex
@@ -1,0 +1,14 @@
+defmodule Tafl.Impl.Player do
+  alias Tafl.Type
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          indicator: Type.player_indicator()
+        }
+  defstruct [:id, :indicator]
+
+  @spec new(String.t(), Type.player_indicator()) :: t()
+  def new(id, indicator) do
+    %__MODULE__{id: id, indicator: indicator}
+  end
+end

--- a/tafl/lib/impl/renderer.ex
+++ b/tafl/lib/impl/renderer.ex
@@ -6,7 +6,7 @@ defmodule Tafl.Impl.Renderer do
           spaces: list(),
           state: Type.state(),
           message: String.t(),
-          turn: Type.player()
+          turn: Type.player_indicator()
         }
 
   defstruct(

--- a/tafl/lib/impl/utils.ex
+++ b/tafl/lib/impl/utils.ex
@@ -1,7 +1,7 @@
 defmodule Tafl.Impl.Utils do
   alias Tafl.Type
 
-  @spec other_player(Type.player()) :: Type.player()
+  @spec other_player(Type.player_indicator()) :: Type.player_indicator()
   def other_player(:p1), do: :p2
   def other_player(:p2), do: :p1
 end

--- a/tafl/lib/impl/win_conditions.ex
+++ b/tafl/lib/impl/win_conditions.ex
@@ -2,7 +2,7 @@ defmodule Tafl.Impl.WinConditions do
   alias Tafl.Impl.Game
   alias Tafl.Type
 
-  @type win_response :: {boolean(), Type.player()}
+  @type win_response :: {boolean(), Type.player_indicator()}
 
   @spec check(Game.t()) :: win_response()
   def check(game) do

--- a/tafl/lib/runtime/server.ex
+++ b/tafl/lib/runtime/server.ex
@@ -11,14 +11,19 @@ defmodule Tafl.Runtime.Server do
     {:ok, Game.new()}
   end
 
-  def handle_call({:make_move, old_loc, new_loc}, _from, game) do
-    updated_game = Game.make_move(game, old_loc, new_loc)
+  def handle_call({:make_move, old_loc, new_loc, player_id}, _from, game) do
+    updated_game = Game.make_move(game, old_loc, new_loc, player_id)
     {:reply, Renderer.render_game(updated_game), updated_game}
   end
 
   def handle_call({:show_board}, _from, game) do
     render = Renderer.render_game(game)
     {:reply, render, game}
+  end
+
+  def handle_call({:add_player, indicator, id}, _from, game) do
+    updated_game = Game.set_player(game, indicator, id)
+    {:reply, Renderer.render_game(updated_game), updated_game}
   end
 
   def handle_call({:game}, _from, game) do

--- a/tafl/lib/tafl.ex
+++ b/tafl/lib/tafl.ex
@@ -8,9 +8,17 @@ defmodule Tafl do
     pid
   end
 
-  @spec make_move(pid(), Type.rc_loc(), Type.rc_loc()) :: Renderer.t()
-  def make_move(game_pid, old_loc, new_loc) do
-    GenServer.call(game_pid, {:make_move, old_loc, new_loc})
+  def add_player_one(game_pid, id) do
+    GenServer.call(game_pid, {:add_player, :p1, id})
+  end
+
+  def add_player_two(game_pid, id) do
+    GenServer.call(game_pid, {:add_player, :p2, id})
+  end
+
+  @spec make_move(pid(), Type.rc_loc(), Type.rc_loc(), String.t()) :: Renderer.t()
+  def make_move(game_pid, old_loc, new_loc, player_id) do
+    GenServer.call(game_pid, {:make_move, old_loc, new_loc, player_id})
   end
 
   @spec show_board(pid()) :: Renderer.t()

--- a/tafl/lib/type.ex
+++ b/tafl/lib/type.ex
@@ -1,7 +1,7 @@
 defmodule Tafl.Type do
   @type game_type :: :basic
   @type state :: :initializing | :waiting | :over | :invalid_move
-  @type player :: :p1 | :p2
+  @type player_indicator :: :p1 | :p2
   @type rc_loc :: {integer(), integer()}
   @type move :: {rc_loc(), rc_loc()}
 end

--- a/text_client/lib/impl/play.ex
+++ b/text_client/lib/impl/play.ex
@@ -1,5 +1,8 @@
 defmodule TextClient.Impl.Play do
   def start(game) do
+    # player ids are not important in single-screen play so give them simple identifiers
+    Tafl.add_player_one(game, "1")
+    Tafl.add_player_two(game, "2")
     render = Tafl.show_board(game)
     interact({game, render})
   end
@@ -16,7 +19,8 @@ defmodule TextClient.Impl.Play do
     IO.write("\n\n")
     IO.write(IO.ANSI.cursor_up(2))
     {old_loc, new_loc} = get_move()
-    render = Tafl.make_move(game, old_loc, new_loc)
+    player_id = if render.turn == :p1, do: "1", else: "2"
+    render = Tafl.make_move(game, old_loc, new_loc, player_id)
     interact({game, render})
   end
 


### PR DESCRIPTION
Currently the text client only supports single-screen play. But the goal for other clients (phoenix) is to allow multi-screen play, with a different player on each screen. Therefore the game must understand the concept of distinct players submitting moves, and must verify that it is actually that player's turn to go. This PR introduces that requirement.

The text client, being single screen, does not actually need to use Player identifiers since it assumes the person making the move is the intended player, so it was updated to infer and provide identifiers automatically.